### PR TITLE
General Repo fixes

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,7 +1,11 @@
 name: Publish Package to npm
+
 on:
   release:
     types: [published]
+
+  workflow_dispatch:
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,13 @@
+Copyright 2025 Gal Angel
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galangel/react-scroll-magic",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Powerful scroll component that feels like magic!",
   "author": "Gal Angel <gal0angel@gmail.com> (@gal.angel)",
   "keywords": [
@@ -9,11 +9,15 @@
     "sticky",
     "list"
   ],
-  "license": "MIT",
+  "license": "Apache-2.0",
   "private": false,
   "repository": {
     "type": "git",
     "url": "git+https://github.com/galangel/react-scroll-magic.git"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   },
   "type": "module",
   "main": "dist/cjs/index.js",


### PR DESCRIPTION
This pull request includes several important changes to the project configuration and licensing. The most significant updates involve adding a new workflow for publishing to npm, updating the licensing information, and modifying the package configuration in `package.json`.

### Workflow and Licensing Updates:

* [`.github/workflows/npm-publish.yml`](diffhunk://#diff-8a5ce8b612395836520d0655143f732d08e747af57f3cfe76b5e283600106240R2-R8): Added a `workflow_dispatch` trigger to allow manual triggering of the publish workflow.

* [`NOTICE`](diffhunk://#diff-dfb14fbb9e7d095209ec4cfd621069437bf9c442ff9de9d4ce889781bd0fefcfR1-R13): Added the Apache License 2.0 notice to the project.

### Package Configuration Updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the version number from `1.0.0` to `1.0.1`.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L12-R21): Changed the license from MIT to Apache-2.0 and added `publishConfig` to specify the npm registry and access level.